### PR TITLE
Option to disable the URL params check when there is need to process all GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Filter is delivered as a standard OSGi bundle. SDI is configured via the configu
 * **Filter selector** - selector used to get actual content
 * **Component TTL** - time to live in seconds, set for rendered component (require Dispatcher 4.1.11+)
 * **Required header** - SDI will be enabled only if the configured header is present in the request. By default it's `Server-Agent=Communique-Dispatcher` header, added by the AEM dispatcher. You may enter just the header name only or the name and the value split with `=`.
+* **Disable Ignore URL params check** - SDI will process all requests and discard ignore URL params check including requests with GET params.
 * **Ignore URL params** - SDI normally skips all requests containing any GET parameters. This option allows to set a list of parameters that should be ignored in the test. See the [Ignoring URL parameters](https://docs.adobe.com/docs/en/dispatcher/disp-config.html#Ignoring%20URL%20Parameters) section in the dispatcher documentation.
 * **Include path rewriting** -- enable rewriting link (according to sling mappings) that is used for dynamic content including.
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
     <build>
         <plugins>
-           <plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
                 <executions>
@@ -74,7 +74,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>        
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </parent>    
     
     <artifactId>org.apache.sling.dynamic-include</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     
     <name>Apache Sling Dynamic Include</name>
@@ -39,7 +39,14 @@
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-dynamic-include.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-dynamic-include.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-dynamic-include.git</url>
-    </scm>    
+    </scm>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sling.url>http://localhost:4502/system/console</sling.url>
+        <sling.username>admin</sling.username>
+        <sling.password>admin</sling.password>
+    </properties>
 
     <developers>
         <developer>
@@ -72,6 +79,12 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <bundleFileName>${project.build.directory}/${project.build.finalName}.jar</bundleFileName>
+                    <user>${sling.username}</user>
+                    <password>${sling.password}</password>
+                    <slingUrl>${sling.url}</slingUrl>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,18 +20,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
         <version>26</version>
         <relativePath />
-    </parent>    
-    
+    </parent>
+
     <artifactId>org.apache.sling.dynamic-include</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    
+
     <name>Apache Sling Dynamic Include</name>
     <description>Dynamic Include filter for Apache Sling</description>
 
@@ -40,13 +40,6 @@
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-dynamic-include.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-dynamic-include.git</url>
     </scm>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sling.url>http://localhost:4502/system/console</sling.url>
-        <sling.username>admin</sling.username>
-        <sling.password>admin</sling.password>
-    </properties>
 
     <developers>
         <developer>
@@ -79,12 +72,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration>
-                    <bundleFileName>${project.build.directory}/${project.build.finalName}.jar</bundleFileName>
-                    <user>${sling.username}</user>
-                    <password>${sling.password}</password>
-                    <slingUrl>${sling.url}</slingUrl>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -54,8 +54,8 @@ import org.osgi.service.component.ComponentContext;
         @Property(name = Configuration.PROPERTY_FILTER_SELECTOR, value = Configuration.DEFAULT_FILTER_SELECTOR, label = "Filter selector", description = "Selector used to mark included resources"),
         @Property(name = Configuration.PROPERTY_COMPONENT_TTL, label = "Component TTL", description = "\"Time to live\" cache header for rendered component (in seconds)"),
         @Property(name = Configuration.PROPERTY_REQUIRED_HEADER, value = Configuration.DEFAULT_REQUIRED_HEADER, label = "Required header", description = "SDI will work only for requests with given header"),
+        @Property(name = Configuration.PROPERTY_DISABLE_IGNORE_URL_PARAMS, boolValue = Configuration.DEFAULT_DISABLE_IGNORE_URL_PARAMS, label = "Disable Ignore URL params check", description = "SDI will process all requests and discard ignore URL params check"),
         @Property(name = Configuration.PROPERTY_IGNORE_URL_PARAMS, cardinality = Integer.MAX_VALUE, label = "Ignore URL params", description = "SDI will process the request even if it contains configured GET parameters"),
-        @Property(name = Configuration.PROPERTY_DISABLE_IGNORE_URL_PARAMS, boolValue = Configuration.DEFAULT_DISABLE_IGNORE_URL_PARAMS, label = "Disable Ignore URL params check and Process all requests", description = "SDI will process all requests and discard ignore URL params check"),
         @Property(name = Configuration.PROPERTY_REWRITE_PATH, boolValue = Configuration.DEFAULT_REWRITE_DISABLED, label = "Include path rewriting", description = "Check to enable include path rewriting") })
 public class Configuration {
 
@@ -87,9 +87,9 @@ public class Configuration {
 
     static final String DEFAULT_REQUIRED_HEADER = "Server-Agent=Communique-Dispatcher";
 
-    static final String PROPERTY_IGNORE_URL_PARAMS = "include-filter.config.ignoreUrlParams";
-
     static final String PROPERTY_DISABLE_IGNORE_URL_PARAMS = "include-filter.config.disable_ignoreUrlParams";
+
+    static final String PROPERTY_IGNORE_URL_PARAMS = "include-filter.config.ignoreUrlParams";
 
     static final String PROPERTY_REWRITE_PATH = "include-filter.config.rewrite";
 
@@ -113,9 +113,9 @@ public class Configuration {
 
     private String requiredHeader;
 
-    private List<String> ignoreUrlParams;
-
     private boolean disableIgnoreUrlParams;
+
+    private List<String> ignoreUrlParams;
 
     private boolean rewritePath;
 
@@ -137,10 +137,10 @@ public class Configuration {
         addComment = PropertiesUtil.toBoolean(properties.get(PROPERTY_ADD_COMMENT), DEFAULT_ADD_COMMENT);
         includeTypeName = PropertiesUtil.toString(properties.get(PROPERTY_INCLUDE_TYPE), DEFAULT_INCLUDE_TYPE);
         requiredHeader = PropertiesUtil.toString(properties.get(PROPERTY_REQUIRED_HEADER), DEFAULT_REQUIRED_HEADER);
-        ignoreUrlParams = Arrays.asList(PropertiesUtil.toStringArray(properties.get(PROPERTY_IGNORE_URL_PARAMS),
-                new String[0]));
         disableIgnoreUrlParams = PropertiesUtil.toBoolean(properties.get(PROPERTY_DISABLE_IGNORE_URL_PARAMS),
                 DEFAULT_DISABLE_IGNORE_URL_PARAMS);
+        ignoreUrlParams = Arrays.asList(PropertiesUtil.toStringArray(properties.get(PROPERTY_IGNORE_URL_PARAMS),
+                new String[0]));
         rewritePath = PropertiesUtil.toBoolean(properties.get(PROPERTY_REWRITE_PATH), DEFAULT_REWRITE_DISABLED);
     }
 

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -55,6 +55,7 @@ import org.osgi.service.component.ComponentContext;
         @Property(name = Configuration.PROPERTY_COMPONENT_TTL, label = "Component TTL", description = "\"Time to live\" cache header for rendered component (in seconds)"),
         @Property(name = Configuration.PROPERTY_REQUIRED_HEADER, value = Configuration.DEFAULT_REQUIRED_HEADER, label = "Required header", description = "SDI will work only for requests with given header"),
         @Property(name = Configuration.PROPERTY_IGNORE_URL_PARAMS, cardinality = Integer.MAX_VALUE, label = "Ignore URL params", description = "SDI will process the request even if it contains configured GET parameters"),
+        @Property(name = Configuration.PROPERTY_DISABLE_IGNORE_URL_PARAMS, boolValue = Configuration.DEFAULT_DISABLE_IGNORE_URL_PARAMS, label = "Disable Ignore URL params check and Process all requests", description = "SDI will process all requests and discard ignore URL params check"),
         @Property(name = Configuration.PROPERTY_REWRITE_PATH, boolValue = Configuration.DEFAULT_REWRITE_DISABLED, label = "Include path rewriting", description = "Check to enable include path rewriting") })
 public class Configuration {
 
@@ -88,7 +89,11 @@ public class Configuration {
 
     static final String PROPERTY_IGNORE_URL_PARAMS = "include-filter.config.ignoreUrlParams";
 
+    static final String PROPERTY_DISABLE_IGNORE_URL_PARAMS = "include-filter.config.disable_ignoreUrlParams";
+
     static final String PROPERTY_REWRITE_PATH = "include-filter.config.rewrite";
+
+    static final boolean DEFAULT_DISABLE_IGNORE_URL_PARAMS = false;
 
     static final boolean DEFAULT_REWRITE_DISABLED = false;
 
@@ -109,6 +114,8 @@ public class Configuration {
     private String requiredHeader;
 
     private List<String> ignoreUrlParams;
+
+    private boolean disableIgnoreUrlParams;
 
     private boolean rewritePath;
 
@@ -132,6 +139,8 @@ public class Configuration {
         requiredHeader = PropertiesUtil.toString(properties.get(PROPERTY_REQUIRED_HEADER), DEFAULT_REQUIRED_HEADER);
         ignoreUrlParams = Arrays.asList(PropertiesUtil.toStringArray(properties.get(PROPERTY_IGNORE_URL_PARAMS),
                 new String[0]));
+        disableIgnoreUrlParams = PropertiesUtil.toBoolean(properties.get(PROPERTY_DISABLE_IGNORE_URL_PARAMS),
+                DEFAULT_DISABLE_IGNORE_URL_PARAMS);
         rewritePath = PropertiesUtil.toBoolean(properties.get(PROPERTY_REWRITE_PATH), DEFAULT_REWRITE_DISABLED);
     }
 
@@ -177,6 +186,10 @@ public class Configuration {
 
     public List<String> getIgnoreUrlParams() {
         return ignoreUrlParams;
+    }
+
+    public boolean isDisableIgnoreUrlParams() {
+        return disableIgnoreUrlParams;
     }
 
     public boolean isRewritePath() {

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -102,7 +102,8 @@ public class IncludeTagFilter implements Filter {
     }
 
     private boolean shouldWriteIncludes(Configuration config, SlingHttpServletRequest request) {
-        if (requestHasParameters(config.getIgnoreUrlParams(), request)) {
+        // Do not skip GET requests when DisableIgnoreUrlParams set to true.
+        if (!config.isDisableIgnoreUrlParams() && requestHasParameters(config.getIgnoreUrlParams(), request)) {
             return false;
         }
         final String requiredHeader = config.getRequiredHeader();


### PR DESCRIPTION
Hi @rombert, @justinedelson, @ieb, @bdelacretaz and @raducotescu 

Good day...

I have requested this new property in SDI to allow support for users who are connecting while commuting (via low bandwidth networks). Enabling this new property in OSGi console will enable **Sling Dynamic Include** for all GET requests and allow us to maximize the dispatcher caching utilization for all GET requests.

We are currently using customized SDI (please see the PR changes) for our website and we would like to get this option included in original SDI repo itself. 
We felt that this custom option would beneficial for others as well.

So that our team can continue using the SDI from apache and will get the benefits/bugfixes from future apache SDI release.



Thanks,
GovindR.