### PR TITLE
Adding a new option to make adding the suffix to the include optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Filter is delivered as a standard OSGi bundle. SDI is configured via the configu
 * **Required header** - SDI will be enabled only if the configured header is present in the request. By default it's `Server-Agent=Communique-Dispatcher` header, added by the AEM dispatcher. You may enter just the header name only or the name and the value split with `=`.
 * **Ignore URL params** - SDI normally skips all requests containing any GET parameters. This option allows to set a list of parameters that should be ignored in the test. See the [Ignoring URL parameters](https://docs.adobe.com/docs/en/dispatcher/disp-config.html#Ignoring%20URL%20Parameters) section in the dispatcher documentation.
 * **Include path rewriting** -- enable rewriting link (according to sling mappings) that is used for dynamic content including.
+* **Append suffix** -- ensures that the suffix of the parent request is included with the dynamic include.
 
 ## Compatibility with components
 

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -62,6 +62,7 @@ import org.slf4j.LoggerFactory;
     @Property(name = Configuration.PROPERTY_REQUIRED_HEADER, value = Configuration.DEFAULT_REQUIRED_HEADER, label = "Required header", description = "SDI will work only for requests with given header"),
     @Property(name = Configuration.PROPERTY_IGNORE_URL_PARAMS, cardinality = Integer.MAX_VALUE, label = "Ignore URL params", description = "SDI will process the request even if it contains configured GET parameters"),
     @Property(name = Configuration.PROPERTY_REWRITE_PATH, boolValue = Configuration.DEFAULT_REWRITE_DISABLED, label = "Include path rewriting", description = "Check to enable include path rewriting"),
+    @Property(name = Configuration.PROPERTY_APPEND_SUFFIX, boolValue = Configuration.DEFAULT_APPEND_SUFFIX, label = "Append suffix to dynamic includes", description = "Check to append the suffix of the parent request to the dynamic include."),
     @Property(name= Configuration.NAME_HINT_PROPERTY_NAME, value=Configuration.NAME_HINT_VALUE)})
 public class Configuration {
 
@@ -110,6 +111,10 @@ public class Configuration {
 
   static final boolean DEFAULT_REWRITE_DISABLED = false;
 
+  static final String PROPERTY_APPEND_SUFFIX = "include-filter.config.appendSuffix";
+
+  static final boolean DEFAULT_APPEND_SUFFIX = true;
+
   private PathMatcher pathMatcher;
 
   private boolean isEnabled;
@@ -131,6 +136,8 @@ public class Configuration {
   private List<String> ignoreUrlParams;
 
   private boolean rewritePath;
+
+  private boolean appendSuffix;
 
   @Activate
   public void activate(ComponentContext context, Map<String, ?> properties) {
@@ -155,6 +162,7 @@ public class Configuration {
     ignoreUrlParams = Arrays.asList(PropertiesUtil.toStringArray(properties.get(PROPERTY_IGNORE_URL_PARAMS),
         new String[0]));
     rewritePath = PropertiesUtil.toBoolean(properties.get(PROPERTY_REWRITE_PATH), DEFAULT_REWRITE_DISABLED);
+    appendSuffix = PropertiesUtil.toBoolean(properties.get(PROPERTY_APPEND_SUFFIX), DEFAULT_APPEND_SUFFIX);
   }
 
   private PathMatcher choosePathMatcher(String pathPattern) {
@@ -228,5 +236,9 @@ public class Configuration {
 
   public boolean isRewritePath() {
     return rewritePath;
+  }
+
+  public boolean isAppendSuffix() {
+      return appendSuffix;
   }
 }

--- a/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
@@ -47,7 +47,9 @@ public final class UrlBuilder {
                 builder.append('.').append(config.getExtension());
             }
         } else {
-            builder.append(StringUtils.defaultString(pathInfo.getSuffix()));
+            if (config.isAppendSuffix()) {
+                builder.append(StringUtils.defaultString(pathInfo.getSuffix()));
+            }
         }
         return builder.toString();
     }

--- a/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
+++ b/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
@@ -30,8 +30,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UrlBuilderTest {
@@ -120,6 +119,21 @@ public class UrlBuilderTest {
         String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
 
         assertThat(actualResult, is("/resource/path.foo.include.html/suffix/to/some/other/information"));
+    }
+
+    @Test
+    public void shouldNotAppendSuffixWhenConfigured() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.include");
+        withSuffixString("/suffix/to/some/other/information");
+        boolean isSyntheticResource = false;
+
+        when(config.isAppendSuffix()).thenReturn(false);
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
+
+        verify(requestPathInfo,times(0)).getSuffix();
+        assertThat(actualResult, is("/resource/path.foo.include.html"));
     }
     
     @Test

--- a/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
+++ b/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
@@ -107,6 +107,20 @@ public class UrlBuilderTest {
 
         assertThat(actualResult, is("/resource/path.foo.include.html/apps/example/resource/type"));
     }
+
+    @Test
+    public void shouldAppendSuffixWhenRequestedByDefault() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.include");
+        withSuffixString("/suffix/to/some/other/information");
+        boolean isSyntheticResource = false;
+
+        when(config.isAppendSuffix()).thenReturn(true);
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.include.html/suffix/to/some/other/information"));
+    }
     
     @Test
     public void shouldAppendExtensionForSyntheticResources() {
@@ -131,5 +145,9 @@ public class UrlBuilderTest {
     private void withSelectorString(String selectorString) {
         when(requestPathInfo.getSelectorString()).thenReturn(selectorString);
         when(requestPathInfo.getSelectors()).thenReturn(StringUtils.defaultString(selectorString).split("\\."));
+    }
+
+    private void withSuffixString(String suffixString) {
+        when(requestPathInfo.getSuffix()).thenReturn(suffixString);
     }
 }


### PR DESCRIPTION
We had a use case where by we needed to make the include semi dynamic. We wanted the parent page that included suffixes to not be cacheable - but wanted the included resources to be cached. This was for a search results page, where it was necessary to cache the content of an individual search result - but not the actual results to display.

However, since the parent request had a suffix - this was passed onto the included resources, which made them non-cacheable. This "appendSuffix" option was added to maintain the current default behaviour, but allow it to be toggled off.