### PR TITLE
Feature/stop selector duplication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </parent>    
     
     <artifactId>org.apache.sling.dynamic-include</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     
     <name>Apache Sling Dynamic Include</name>

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -39,11 +39,11 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingFilter;
 import org.apache.felix.scr.annotations.sling.SlingFilterScope;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
 import org.apache.sling.dynamicinclude.generator.IncludeGeneratorWhiteboard;
+import org.apache.sling.dynamicinclude.impl.UrlBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,24 +160,9 @@ public class IncludeTagFilter implements Filter {
     }
 
     private String buildUrl(Configuration config, SlingHttpServletRequest request) {
-        final boolean synthetic = ResourceUtil.isSyntheticResource(request.getResource());
         final Resource resource = request.getResource();
-        final StringBuilder builder = new StringBuilder();
-        final RequestPathInfo pathInfo = request.getRequestPathInfo();
-
-        final String resourcePath = pathInfo.getResourcePath();
-        builder.append(resourcePath);
-        if (pathInfo.getSelectorString() != null) {
-            builder.append('.').append(sanitize(pathInfo.getSelectorString()));
-        }
-        builder.append('.').append(config.getIncludeSelector());
-        builder.append('.').append(pathInfo.getExtension());
-        if (synthetic) {
-            builder.append('/').append(resource.getResourceType());
-        } else {
-            builder.append(sanitize(pathInfo.getSuffix()));
-        }
-        return builder.toString();
+        final boolean synthetic = ResourceUtil.isSyntheticResource(request.getResource());
+        return UrlBuilder.buildUrl(config.getIncludeSelector(), resource.getResourceType(), synthetic, request.getRequestPathInfo());
     }
 
     private static String sanitize(String path) {

--- a/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
@@ -1,0 +1,54 @@
+/*-
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.dynamicinclude.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.request.RequestPathInfo;
+
+import java.util.Arrays;
+
+public final class UrlBuilder {
+
+
+    public static String buildUrl(String includeSelector, String resourceType, boolean synthetic, RequestPathInfo pathInfo) {
+        final StringBuilder builder = new StringBuilder();
+
+        final String resourcePath = pathInfo.getResourcePath();
+        builder.append(resourcePath);
+        String currentSelectorString = StringUtils.defaultString(pathInfo.getSelectorString());
+        if (pathInfo.getSelectorString() != null) {
+            builder.append('.').append(currentSelectorString);
+        }
+        if (includeSelectorNotAlreadyPresent(pathInfo.getSelectors(), includeSelector)) {
+            builder.append('.').append(includeSelector);
+        }
+        builder.append('.').append(pathInfo.getExtension());
+        if (synthetic) {
+            builder.append('/').append(resourceType);
+        } else {
+            builder.append(StringUtils.defaultString(pathInfo.getSuffix()));
+        }
+        return builder.toString();
+    }
+
+    private static boolean includeSelectorNotAlreadyPresent(String[] currentSelectors, String includeSelector) {
+        return !Arrays.asList(currentSelectors).contains(includeSelector);
+    }
+}

--- a/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
+++ b/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
@@ -1,0 +1,114 @@
+/*-
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.dynamicinclude.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UrlBuilderTest {
+
+    @Mock
+    private RequestPathInfo requestPathInfo;
+
+    @Test
+    public void shouldAppendTheIncludeSelectorToUrlWithNoSelectors() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString(null);
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.include.html"));
+    }
+
+    @Test
+    public void shouldAppendTheIncludeSelectorToUrlThatAlreadyContainsOtherSelectors() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.bar.baz");
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.bar.baz.include.html"));
+    }
+
+    @Test
+    public void shouldAppendTheIncludeSelectorToUrlContainingMixedAlphanumericSelectors() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.2.31");
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.2.31.include.html"));
+    }
+
+    @Test
+    public void shouldNotDuplicateTheIncludeSelectorIfAlreadyPresent() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.include");
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.include.html"));
+    }
+
+    @Test
+    public void shouldAppendTheIncludeSelectorWhenThereIsAnotherSelectorThatAccidentallyContainsTheIncludeOne() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("longerSelectorThatHappensToContainTheIncludeSelector");
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("IncludeSelector", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.longerSelectorThatHappensToContainTheIncludeSelector.IncludeSelector.html"));
+    }
+
+    @Test
+    public void shouldAppendSuffixForSyntheticResources() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.include");
+        boolean isSyntheticResource = true;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.include.html/apps/example/resource/type"));
+    }
+
+    private void givenAnHtmlRequestForResource(String resourcePath) {
+        when(requestPathInfo.getExtension()).thenReturn("html");
+        when(requestPathInfo.getResourcePath()).thenReturn(resourcePath);
+    }
+
+    private void withSelectorString(String selectorString) {
+        when(requestPathInfo.getSelectorString()).thenReturn(selectorString);
+        when(requestPathInfo.getSelectors()).thenReturn(StringUtils.defaultString(selectorString).split("\\."));
+    }
+}


### PR DESCRIPTION
A proposed way of resolving https://issues.apache.org/jira/browse/SLING-7742

Supposed we have two components that SDI is set up to include with SSI. A selector is added to every such request. If one component contains the other, SDI will append the selector twice, even if it's the same.

This PR introduces a code change that prevents that and number of unit test scenarios covering various cases.