### PR TITLE
Allow caching of virtual resources

### DIFF
--- a/src/main/java/org/apache/sling/dynamicinclude/CacheControlFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/CacheControlFilter.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 @SlingFilter(scope = SlingFilterScope.REQUEST, order = 0)
 public class CacheControlFilter implements Filter {
 
+    private static final String HEADER_DATE = "Date";
+
     private static final String HEADER_CACHE_CONTROL = "Cache-Control";
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheControlFilter.class);
@@ -57,6 +59,9 @@ public class CacheControlFilter implements Filter {
             SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) response;
             slingResponse.setHeader(HEADER_CACHE_CONTROL, "max-age=" + config.getTtl());
             LOG.debug("set \"{}: max-age={}\" to {}", HEADER_CACHE_CONTROL, config.getTtl(), resourceType);
+            if (!slingResponse.containsHeader(HEADER_DATE)) {
+                slingResponse.setDateHeader(HEADER_DATE, System.currentTimeMillis());
+            }
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
         @PropertyOption(name = "JSI", value = "Javascript")}),
     @Property(name = Configuration.PROPERTY_ADD_COMMENT, boolValue = Configuration.DEFAULT_ADD_COMMENT, label = "Add comment", description = "Add comment to included components"),
     @Property(name = Configuration.PROPERTY_FILTER_SELECTOR, value = Configuration.DEFAULT_FILTER_SELECTOR, label = "Filter selector", description = "Selector used to mark included resources"),
+    @Property(name = Configuration.PROPERTY_EXTENSION, value = Configuration.DEFAULT_EXTENSION, label = "Extension", description = "Extension to append to virtual resources to make caching possible"),
     @Property(name = Configuration.PROPERTY_COMPONENT_TTL, label = "Component TTL", description = "\"Time to live\" cache header for rendered component (in seconds)"),
     @Property(name = Configuration.PROPERTY_REQUIRED_HEADER, value = Configuration.DEFAULT_REQUIRED_HEADER, label = "Required header", description = "SDI will work only for requests with given header"),
     @Property(name = Configuration.PROPERTY_IGNORE_URL_PARAMS, cardinality = Integer.MAX_VALUE, label = "Ignore URL params", description = "SDI will process the request even if it contains configured GET parameters"),
@@ -79,6 +80,10 @@ public class Configuration {
   static final String PROPERTY_FILTER_SELECTOR = "include-filter.config.selector";
 
   static final String DEFAULT_FILTER_SELECTOR = "nocache";
+
+  static final String PROPERTY_EXTENSION = "include-filter.config.extension";
+
+  static final String DEFAULT_EXTENSION = "";
 
   static final String PROPERTY_COMPONENT_TTL = "include-filter.config.ttl";
 
@@ -111,6 +116,8 @@ public class Configuration {
 
   private String includeSelector;
 
+  private String extension;
+
   private int ttl;
 
   private List<String> resourceTypes;
@@ -140,6 +147,7 @@ public class Configuration {
     this.resourceTypes = Arrays.asList(resourceTypeList);
 
     includeSelector = PropertiesUtil.toString(properties.get(PROPERTY_FILTER_SELECTOR), DEFAULT_FILTER_SELECTOR);
+    extension = PropertiesUtil.toString(properties.get(PROPERTY_EXTENSION), DEFAULT_EXTENSION);
     ttl = PropertiesUtil.toInteger(properties.get(PROPERTY_COMPONENT_TTL), -1);
     addComment = PropertiesUtil.toBoolean(properties.get(PROPERTY_ADD_COMMENT), DEFAULT_ADD_COMMENT);
     includeTypeName = PropertiesUtil.toString(properties.get(PROPERTY_INCLUDE_TYPE), DEFAULT_INCLUDE_TYPE);
@@ -171,6 +179,19 @@ public class Configuration {
 
   public String getIncludeSelector() {
     return includeSelector;
+  }
+
+  public boolean hasExtension(final SlingHttpServletRequest request) {
+    final String suffix = request.getRequestPathInfo().getSuffix();
+    return suffix.endsWith("." + this.extension);
+  }
+
+  public boolean hasExtensionSet() {
+    return StringUtils.isNotBlank(this.extension);
+  }
+
+  public String getExtension() {
+    return this.extension;
   }
 
   public boolean hasTtlSet() {

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -161,8 +161,9 @@ public class IncludeTagFilter implements Filter {
 
     private String buildUrl(Configuration config, SlingHttpServletRequest request) {
         final Resource resource = request.getResource();
+
         final boolean synthetic = ResourceUtil.isSyntheticResource(request.getResource());
-        return UrlBuilder.buildUrl(config.getIncludeSelector(), resource.getResourceType(), synthetic, request.getRequestPathInfo());
+        return UrlBuilder.buildUrl(config.getIncludeSelector(), resource.getResourceType(), synthetic, config, request.getRequestPathInfo());
     }
 
     private static String sanitize(String path) {

--- a/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
@@ -19,15 +19,16 @@
 
 package org.apache.sling.dynamicinclude.impl;
 
+import java.util.Arrays;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.request.RequestPathInfo;
-
-import java.util.Arrays;
+import org.apache.sling.dynamicinclude.Configuration;
 
 public final class UrlBuilder {
 
 
-    public static String buildUrl(String includeSelector, String resourceType, boolean synthetic, RequestPathInfo pathInfo) {
+    public static String buildUrl(String includeSelector, String resourceType, boolean synthetic, Configuration config, RequestPathInfo pathInfo) {
         final StringBuilder builder = new StringBuilder();
 
         final String resourcePath = pathInfo.getResourcePath();
@@ -42,6 +43,9 @@ public final class UrlBuilder {
         builder.append('.').append(pathInfo.getExtension());
         if (synthetic) {
             builder.append('/').append(resourceType);
+            if (config.hasExtensionSet()) {
+                builder.append('.').append(config.getExtension());
+            }
         } else {
             builder.append(StringUtils.defaultString(pathInfo.getSuffix()));
         }

--- a/src/main/java/org/apache/sling/dynamicinclude/package-info.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/package-info.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@Version("4.0.0")
+@Version("4.1.0")
 package org.apache.sling.dynamicinclude;
 import aQute.bnd.annotation.Version;
 


### PR DESCRIPTION
Due to the need to append the resource type as a suffix for virtual resources, AEMs Dispatcher is not able to cache those requests. This is mended by introducing a extra extension, that is appended to the suffix.