### PR TITLE
Fix documentation for httpd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After setting output filter open virtualhost configuration and add `Includes` op
             AllowOverride None
         </Directory>
         <Directory /var/www/>
-            Options Indexes FollowSymLinks MultiViews Includes
+            Options Indexes FollowSymLinks Includes
             AllowOverride None
             Order allow,deny
             allow from all


### PR DESCRIPTION
`MultiViews` breaks the configuration, for items that are not cached. https://www.bennadel.com/blog/2218-negotiation-discovered-file-s-matching-request-none-could-be-negotiated.htm gave me enough info to determine that I was having the same exact problem.

`MultiViews` is not needed for SDI to work properly.