### PR TITLE
SLING-8377 : [BUGFIX] Sling Dynamic Include - Does not support empty "include selector" option.

### DIFF
--- a/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/impl/UrlBuilder.java
@@ -55,6 +55,9 @@ public final class UrlBuilder {
     }
 
     private static boolean includeSelectorNotAlreadyPresent(String[] currentSelectors, String includeSelector) {
+        if (includeSelector.isEmpty()) {
+            return false;
+        }
         return !Arrays.asList(currentSelectors).contains(includeSelector);
     }
 }

--- a/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
+++ b/src/test/java/org/apache/sling/dynamicinclude/impl/UrlBuilderTest.java
@@ -53,6 +53,39 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void shouldNotAppendTheIncludeSelectorToUrlWhenNotSetAndAppendRequestPathInfoSelectorWhenNotSet() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString(null);
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.html"));
+    }
+
+    @Test
+    public void shouldNotAppendTheIncludeSelectorToUrlWhenNotSetAndAppendRequestPathInfoSelectorWhenSet() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString("foo.bar.baz");
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.foo.bar.baz.html"));
+    }
+
+    @Test
+    public void shouldAppendTheIncludeSelectorToUrlWhenSetAndNotAppendRequestPathInfoSelectorWhenNotSet() {
+        givenAnHtmlRequestForResource("/resource/path");
+        withSelectorString(null);
+        boolean isSyntheticResource = false;
+
+        String actualResult = UrlBuilder.buildUrl("include", "apps/example/resource/type", isSyntheticResource, config, requestPathInfo);
+
+        assertThat(actualResult, is("/resource/path.include.html"));
+    }
+
+    @Test
     public void shouldAppendTheIncludeSelectorToUrlThatAlreadyContainsOtherSelectors() {
         givenAnHtmlRequestForResource("/resource/path");
         withSelectorString("foo.bar.baz");
@@ -135,7 +168,7 @@ public class UrlBuilderTest {
         verify(requestPathInfo,times(0)).getSuffix();
         assertThat(actualResult, is("/resource/path.foo.include.html"));
     }
-    
+
     @Test
     public void shouldAppendExtensionForSyntheticResources() {
         givenAnHtmlRequestForResource("/resource/path");


### PR DESCRIPTION
After testing out Sling Dynamic Include 3.1.2, it seems like setting an option (include-filter.config.selector) to BLANK is not supported.

**Scenario:**
AEM 6.4.*, after installing Dynamic Include, I will configure the OSGI configuration. With an option of an input field (include-filter.config.selector) set to blank, my rendered page received a double dot notation. 

**Actual (notice the double dot notation) :**
${root}/resource/path..html

**Expected :**
${root}/resource/path.html

Ticket: https://issues.apache.org/jira/browse/SLING-8377?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=16833618