### PR TITLE
add Forward filter scope to CacheControlFilter

### DIFF
--- a/src/main/java/org/apache/sling/dynamicinclude/CacheControlFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/CacheControlFilter.java
@@ -36,7 +36,7 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SlingFilter(scope = SlingFilterScope.REQUEST, order = 0)
+@SlingFilter(scope = {SlingFilterScope.REQUEST, SlingFilterScope.FORWARD}, order = 0)
 public class CacheControlFilter implements Filter {
 
     private static final String HEADER_DATE = "Date";

--- a/src/main/java/org/apache/sling/dynamicinclude/SyntheticResourceFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/SyntheticResourceFilter.java
@@ -47,7 +47,7 @@ import org.osgi.framework.Constants;
 @Properties({
         @Property(name = Constants.SERVICE_VENDOR, value = "The Apache Software Foundation"),
         @Property(name = EngineConstants.SLING_FILTER_SCOPE, value = EngineConstants.FILTER_SCOPE_REQUEST, propertyPrivate = true),
-        @Property(name = Constants.SERVICE_RANKING, intValue = Integer.MIN_VALUE, propertyPrivate = false), })
+        @Property(name = Constants.SERVICE_RANKING, intValue = Integer.MIN_VALUE, propertyPrivate = false) })
 public class SyntheticResourceFilter implements Filter {
 
     @Reference


### PR DESCRIPTION
The CacheControlFilter servlet is missing the `SlingFilterScope.FORWARD` scope which is needed to receive the forced resourceType set by the SyntheticResourceFilter for synthetic resources.

JIRA ticket has been created here: https://issues.apache.org/jira/browse/SLING-8427