### PR TITLE
SLING-9247 Use Set instead of List to test  ignoreUrlParams

### DIFF
--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -20,6 +20,8 @@
 package org.apache.sling.dynamicinclude;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -121,7 +123,7 @@ public class Configuration {
 
   private boolean disableIgnoreUrlParams;
 
-  private List<String> ignoreUrlParams;
+  private Collection<String> ignoreUrlParams;
 
   private boolean rewritePath;
 
@@ -147,8 +149,9 @@ public class Configuration {
     addComment = cfg.include$_$filter_config_add__comment();
     includeTypeName = cfg.include$_$filter_config_include$_$type();
     requiredHeader = cfg.include$_$filter_config_required__header();
-    ignoreUrlParams = Arrays.asList(PropertiesUtil.toStringArray(cfg.include$_$filter_config_ignoreUrlParams(),
-        new String[0]));
+    ignoreUrlParams = new HashSet<>(
+            Arrays.asList(PropertiesUtil.toStringArray(cfg.include$_$filter_config_ignoreUrlParams(), new String[0]))
+    );
     rewritePath = cfg.include$_$filter_config_rewrite();
     appendSuffix = cfg.include$_$filter_config_appendSuffix();
     disableIgnoreUrlParams = cfg.include$_$filter_config_disableIgnoreUrlParams();
@@ -219,7 +222,7 @@ public class Configuration {
     return requiredHeader;
   }
 
-  public List<String> getIgnoreUrlParams() {
+  public Collection<String> getIgnoreUrlParams() {
     return ignoreUrlParams;
   }
 

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -113,7 +114,7 @@ public class IncludeTagFilter implements Filter {
         return StringUtils.isBlank(requiredHeader) || containsHeader(requiredHeader, request);
     }
 
-    private boolean requestHasParameters(List<String> ignoreUrlParams, SlingHttpServletRequest request) {
+    private boolean requestHasParameters(Collection<String> ignoreUrlParams, SlingHttpServletRequest request) {
         final Enumeration<?> paramNames = request.getParameterNames();
         while (paramNames.hasMoreElements()) {
             final String paramName = (String) paramNames.nextElement();


### PR DESCRIPTION
In our setup we have a list of ignored GET parameters (_include-filter.config.ignoreUrlParams_) which grew with time to a hundred or so elements .

_org.apache.sling.dynamicinclude.Configuration_ loads these into a _java.util.List_ which is further  checked from IncludeTagFilter via _List#contains_

Calling _List#contains_ in a loop is kind of a smell.  I believe _java.util.Set_ will be a more appropriate containter with fixed O(1) cost of _contains()_. 

