### PR TITLE
Extend the IncludeGenerator interface with the Sling Request 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </parent>    
     
     <artifactId>org.apache.sling.dynamic-include</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     
     <name>Apache Sling Dynamic Include</name>
     <description>Dynamic Include filter for Apache Sling</description>
@@ -69,6 +69,10 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -71,7 +71,7 @@ public class Configuration {
       @AttributeDefinition(name="Add comment", description = "Add comment to included components")
       boolean include$_$filter_config_add__comment() default false;
       
-      @AttributeDefinition(name = "Filter selector", description = "Selector used to mark included resources")
+      @AttributeDefinition(name = "Filter selector", description = "Selector used to mark included resources. The Built in option are 'SSI','ESI' and 'JSI'")
       String include$_$filter_config_selector() default "nocache";
 
       @AttributeDefinition(name = "Extension", description = "Extension to append to virtual resources to make caching possible")

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -38,7 +38,6 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
-import org.osgi.service.metatype.annotations.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/Configuration.java
@@ -66,11 +66,7 @@ public class Configuration {
       @AttributeDefinition(name="Resource types", description="Filter will replace components with selected resource types", cardinality = Integer.MAX_VALUE)
       String include$_$filter_config_resource$_$types() default "";
       
-      @AttributeDefinition(name = "Include type", description = "Type of generated include tags", options = {
-          @Option(label = "Apache SSI", value = "SSI"),
-          @Option(label = "ESI", value = "ESI"),
-          @Option(label = "Javascript", value = "JSI")
-      })
+      @AttributeDefinition(name = "Include type", description = "Type of generated include tags")
       String include$_$filter_config_include$_$type() default "SSI";
       
       @AttributeDefinition(name="Add comment", description = "Add comment to included components")

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.List;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -39,7 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
+import org.apache.sling.dynamicinclude.api.IncludeGenerator;
 import org.apache.sling.dynamicinclude.generator.IncludeGeneratorWhiteboard;
 import org.apache.sling.dynamicinclude.impl.UrlBuilder;
 import org.apache.sling.servlets.annotations.SlingServletFilter;

--- a/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/IncludeTagFilter.java
@@ -97,7 +97,7 @@ public class IncludeTagFilter implements Filter {
         // Only write the includes markup if the required, configurable request
         // header is present
         if (shouldWriteIncludes(config, slingRequest)) {
-            String include = generator.getInclude(url);
+            String include = generator.getInclude(slingRequest,url);
             LOG.debug(include);
             writer.append(include);
         } else {

--- a/src/main/java/org/apache/sling/dynamicinclude/api/IncludeGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/api/IncludeGenerator.java
@@ -27,5 +27,21 @@ import org.apache.sling.api.SlingHttpServletRequest;
 public interface IncludeGenerator {
     String getType();
 
-    String getInclude(SlingHttpServletRequest request,String url);
+    /**
+     * Returns the string used to include the resource.
+     * For example, this might be a Javascript code that retrieves a snippet of html,
+     * an Apache SSI Tag, or an Edge Side Include Tag.
+     * <p>
+     * This method receives the sling request and an Url that has already be normalized as followed:
+     * <ul>
+     * <li>The query string has been removed</li>
+     * <li>The Url has been mapped using the ResourceResolver</li>
+     * <li>The jcr:content paths have been encoded to _jcr_content.</li>
+     * </ul>
+     *
+     * @param request       the Sling request object
+     * @param normalizedUrl the requested url, normalized
+     * @return a String used to include the resource
+     **/
+    String getInclude(SlingHttpServletRequest request, String normalizedUrl);
 }

--- a/src/main/java/org/apache/sling/dynamicinclude/api/IncludeGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/api/IncludeGenerator.java
@@ -17,31 +17,15 @@
  * under the License.
  */
 
-package org.apache.sling.dynamicinclude.generator.types;
+package org.apache.sling.dynamicinclude.api;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.dynamicinclude.api.IncludeGenerator;
-import org.osgi.service.component.annotations.Component;
 
 /**
- * ESI include generator
+ * Include generator interface
  */
-@Component
-public class EsiGenerator implements IncludeGenerator {
-    private static final String GENERATOR_NAME = "ESI";
+public interface IncludeGenerator {
+    String getType();
 
-    @Override
-    public String getType() {
-        return GENERATOR_NAME;
-    }
-
-    @Override
-    public String getInclude(SlingHttpServletRequest request, String url) {
-        StringBuffer buf = new StringBuffer();
-        buf.append("<esi:include src=\"");
-        buf.append(StringEscapeUtils.escapeHtml4(url));
-        buf.append("\"/>");
-        return buf.toString();
-    }
+    String getInclude(SlingHttpServletRequest request,String url);
 }

--- a/src/main/java/org/apache/sling/dynamicinclude/api/package-info.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/api/package-info.java
@@ -17,15 +17,7 @@
  * under the License.
  */
 
-package org.apache.sling.dynamicinclude.generator;
+@Version("1.0.0")
+package org.apache.sling.dynamicinclude.api;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-
-/**
- * Include generator interface
- */
-public interface IncludeGenerator {
-    String getType();
-
-    String getInclude(SlingHttpServletRequest request,String url);
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/IncludeGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/IncludeGenerator.java
@@ -19,11 +19,13 @@
 
 package org.apache.sling.dynamicinclude.generator;
 
+import org.apache.sling.api.SlingHttpServletRequest;
+
 /**
  * Include generator interface
  */
 public interface IncludeGenerator {
     String getType();
 
-    String getInclude(String url);
+    String getInclude(SlingHttpServletRequest request,String url);
 }

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/IncludeGeneratorWhiteboard.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/IncludeGeneratorWhiteboard.java
@@ -26,6 +26,7 @@ import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.apache.sling.dynamicinclude.api.IncludeGenerator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/types/EsiGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/types/EsiGenerator.java
@@ -20,6 +20,7 @@
 package org.apache.sling.dynamicinclude.generator.types;
 
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
 import org.osgi.service.component.annotations.Component;
 
@@ -36,7 +37,7 @@ public class EsiGenerator implements IncludeGenerator {
     }
 
     @Override
-    public String getInclude(String url) {
+    public String getInclude(SlingHttpServletRequest request, String url) {
         StringBuffer buf = new StringBuffer();
         buf.append("<esi:include src=\"");
         buf.append(StringEscapeUtils.escapeHtml4(url));

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/types/JsiGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/types/JsiGenerator.java
@@ -27,6 +27,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -69,7 +70,7 @@ public class JsiGenerator implements IncludeGenerator {
     }
 
     @Override
-    public String getInclude(String url) {
+    public String getInclude(SlingHttpServletRequest request, String url) {
         if (template == null) {
             throw new IllegalStateException("JSI generator hasn't be initialized");
         }

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/types/JsiGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/types/JsiGenerator.java
@@ -28,7 +28,7 @@ import java.net.URL;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
+import org.apache.sling.dynamicinclude.api.IncludeGenerator;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/types/SsiGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/types/SsiGenerator.java
@@ -20,6 +20,7 @@
 package org.apache.sling.dynamicinclude.generator.types;
 
 import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -35,7 +36,7 @@ public class SsiGenerator implements IncludeGenerator {
     }
 
     @Override
-    public String getInclude(String url) {
+    public String getInclude(SlingHttpServletRequest request, String url) {
         StringBuffer buf = new StringBuffer();
         buf.append("<!--#include virtual=\"");
         buf.append(escapeForApache(url));

--- a/src/main/java/org/apache/sling/dynamicinclude/generator/types/SsiGenerator.java
+++ b/src/main/java/org/apache/sling/dynamicinclude/generator/types/SsiGenerator.java
@@ -19,8 +19,8 @@
 
 package org.apache.sling.dynamicinclude.generator.types;
 
-import org.apache.sling.dynamicinclude.generator.IncludeGenerator;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.dynamicinclude.api.IncludeGenerator;
 import org.osgi.service.component.annotations.Component;
 
 /**


### PR DESCRIPTION
Extend the IncludeGenerator interface with the Sling Request to give more flexibility to potential implementations of the interface.