### PR TITLE
Moving the JS calling part into the DIV, thus it get replaced after d…

### DIFF
--- a/src/main/resources/generators/javascript.html
+++ b/src/main/resources/generators/javascript.html
@@ -6,9 +6,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,21 +16,22 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<div id="${uniqueId}"></div>
-<script type="text/javascript">
-    if (window.XMLHttpRequest) {
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', encodeURI("${url}"));
-        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-        xhr.timeout = 10000;
-        xhr.onload = function () {
-            if (xhr.status >= 200 && xhr.status < 300) {
-                var elemId = document.getElementById('${uniqueId}');
-                if (elemId) elemId.innerHTML = xhr.responseText;
-            }
-        };
-        xhr.send();
-    }
+<div id="${uniqueId}">
+    <script type="text/javascript">
+        if (window.XMLHttpRequest) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', encodeURI("${url}"));
+            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            xhr.timeout = 10000;
+            xhr.onload = function () {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    var elemId = document.getElementById('${uniqueId}');
+                    if (elemId) elemId.innerHTML = xhr.responseText;
+                }
+            };
+            xhr.send();
+        }
 
-</script>
-<noscript>Your browser does not support JavaScript. Some components may not be visible.</noscript>
+    </script>
+    <noscript>Your browser does not support JavaScript. Some components may not be visible.</noscript>
+</div>


### PR DESCRIPTION
Moving the JS calling part into the DIV, thus it get replaced after data is loaded. 
This helps while migrating components to be fetched via JSI as no additional tags & code is introduced, which leads to fewer changes on the existing Java Script.
It also keeps the resulting code cleaner